### PR TITLE
feat: support compiled Allure2 reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ By abstracting the data access behind `AllureReader` and `AllureWriter` interfac
 
 - **Unified API**: Interact with Allure test results, containers, categories, environment, and executor info using a single, simple API (`AllureStore`).
 - **Filesystem Integration**: Use built-in utilities to read from/write to a traditional `allure-results` directory.
+- **Compiled Report Support**: Read compiled Allure2 reports — local directories, HTTP URLs, and single-file HTML reports — via `fromReport`.
 - **Custom Integration Points**: Implement `AllureReader` and `AllureWriter` interfaces to read from or write to any storage backend—databases, cloud storage, etc.
 - **Result Aggregation**: Merge parent test containers and child results to produce enriched test data for Allure-compatible tools.
 - **Flexible Composition**: Combine multiple data sources or transform results before finalizing your Allure report.
@@ -82,6 +83,34 @@ import { fromDirectory } from 'allure-store';
   ]);
 })();
 ```
+
+### Reading a Compiled Allure2 Report
+
+If you have a compiled Allure2 report (the output of `allure generate`), use `fromReport`. It accepts a local directory, a local HTML file, an HTTP(S) URL, or a `file://` URL:
+
+```typescript
+import { fromReport } from 'allure-store';
+
+(async () => {
+  // From a local report directory
+  const store = await fromReport('/path/to/allure-report');
+
+  // From a single-file HTML report
+  const store2 = await fromReport('/path/to/report.html');
+
+  // From a URL (auto-detects multi-file vs single-file)
+  const store3 = await fromReport('https://my-report.example.com/');
+
+  const allResults = await store.getAllResults();
+  console.log('All test results:', allResults.length);
+
+  // Latest results deduplicated by historyId (retries resolved)
+  const latestResults = await store.getLatestResults();
+  console.log('Unique tests:', latestResults.length);
+})();
+```
+
+> **Note:** Compiled reports are read-only. Write operations will throw an error.
 
 ### Using Custom Readers/Writers
 

--- a/src/AllureStore.ts
+++ b/src/AllureStore.ts
@@ -1,22 +1,31 @@
+import fs from 'node:fs/promises';
+
 import type { AllureReader } from './AllureReader';
 import type { AllureWriter } from './AllureWriter';
+import { CompiledAllureReader } from './CompiledAllureReader';
+import { FileReportSource, UrlReportSource, HtmlReportSource, containsHtmlDataCalls, stripFileProtocol } from './CompiledReportSource';
+import type { OnErrorHandler } from './errors';
 import { FileAllureReader } from './FileAllureReader';
 import { FileAllureWriter } from './FileAllureWriter';
 import type { Category, CategoryInput, Container, ExecutorInfo, Result } from './types';
 
 export interface AllureStoreConfig {
   reader: AllureReader;
-  writer: AllureWriter;
+  writer?: AllureWriter;
 }
 
 export interface AllureStoreDirectoryConfig {
   overwrite?: boolean;
-  onError?: ((error: Error) => void) | 'throw' | 'ignore';
+  onError?: OnErrorHandler;
+}
+
+export interface AllureStoreReportConfig {
+  onError?: OnErrorHandler;
 }
 
 export class AllureStore {
   readonly #reader: AllureReader;
-  readonly #writer: AllureWriter;
+  readonly #writer: AllureWriter | undefined;
 
   constructor(config: AllureStoreConfig) {
     this.#reader = config.reader;
@@ -24,7 +33,7 @@ export class AllureStore {
   }
 
   static async fromConfig(config: AllureStoreConfig): Promise<AllureStore> {
-    await Promise.all([config.reader.init?.(), config.writer.init?.()]);
+    await Promise.all([config.reader.init?.(), config.writer?.init?.()]);
     return new AllureStore(config);
   }
 
@@ -32,6 +41,31 @@ export class AllureStore {
     const reader: AllureReader = new FileAllureReader({ resultsDirectory, onError: config.onError });
     const writer: AllureWriter = new FileAllureWriter({ resultsDirectory, onError: config.onError, overwrite: config.overwrite });
     return AllureStore.fromConfig({ reader, writer });
+  }
+
+  static async fromReport(input: string, options: AllureStoreReportConfig = {}): Promise<AllureStore> {
+    const localPath = stripFileProtocol(input);
+
+    if (!localPath.startsWith('http://') && !localPath.startsWith('https://')) {
+      const stat = await fs.stat(localPath).catch(() => null);
+      if (stat?.isDirectory()) {
+        return AllureStore.fromConfig({ reader: new CompiledAllureReader({ source: new FileReportSource(localPath), ...options }) });
+      }
+      if (stat?.isFile()) {
+        return AllureStore.fromConfig({ reader: new CompiledAllureReader({ source: new HtmlReportSource(localPath), ...options }) });
+      }
+      throw new Error(`Cannot resolve report input: ${input}`);
+    }
+
+    const response = await fetch(localPath);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch report: ${response.status} ${response.statusText}`);
+    }
+    const html = await response.text();
+    if (containsHtmlDataCalls(html)) {
+      return AllureStore.fromConfig({ reader: new CompiledAllureReader({ source: new HtmlReportSource(localPath, html), ...options }) });
+    }
+    return AllureStore.fromConfig({ reader: new CompiledAllureReader({ source: new UrlReportSource(localPath), ...options }) });
   }
 
   //#region Reading methods
@@ -83,23 +117,30 @@ export class AllureStore {
 
   //#region Writing methods
   async writeCategories(categories: CategoryInput[]): Promise<void> {
-    return this.#writer.writeCategories(categories);
+    return this.#requireWriter().writeCategories(categories);
   }
 
   async writeEnvironmentInfo(info: Record<string, string>): Promise<void> {
-    return this.#writer.writeEnvironmentInfo(info);
+    return this.#requireWriter().writeEnvironmentInfo(info);
   }
 
   async writeExecutorInfo(info: ExecutorInfo): Promise<void> {
-    return this.#writer.writeExecutorInfo(info);
+    return this.#requireWriter().writeExecutorInfo(info);
   }
 
   async writeResult(result: Result): Promise<void> {
-    return this.#writer.writeResult(result);
+    return this.#requireWriter().writeResult(result);
   }
 
   async writeContainer(container: Container): Promise<void> {
-    return this.#writer.writeContainer(container);
+    return this.#requireWriter().writeContainer(container);
+  }
+
+  #requireWriter(): AllureWriter {
+    if (!this.#writer) {
+      throw new Error('This store is read-only (no writer configured)');
+    }
+    return this.#writer;
   }
   //#endregion
 

--- a/src/CompiledAllureReader.test.ts
+++ b/src/CompiledAllureReader.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, beforeEach } from 'node:test';
+
+import { expect } from 'chai';
+
+import { mapCompiledTestCase, CompiledAllureReader } from './CompiledAllureReader';
+import type { CompiledReportSource } from './CompiledReportSource';
+import type { Status } from './types';
+
+interface StubStep {
+  name: string;
+  time: { start: number; stop: number; duration: number };
+  status: Status;
+  steps: StubStep[];
+  attachments: { uid?: string; name: string; type: string; source: string; size?: number }[];
+  parameters: { name: string; value: string }[];
+}
+
+function step(name: string, overrides: Partial<StubStep> = {}): StubStep {
+  return {
+    name,
+    time: { start: 1, stop: 2, duration: 1 },
+    status: 'passed',
+    steps: [],
+    attachments: [],
+    parameters: [],
+    ...overrides,
+  };
+}
+
+function baseCompiledTestCase() {
+  return {
+    uid: 'abc123',
+    historyId: 'hist456',
+    name: 'Test Name',
+    fullName: '[android] Suite - Test Name',
+    time: { start: 1000, stop: 2000, duration: 1000 },
+    status: 'passed' as Status,
+    flaky: false,
+    newFailed: false,
+    newBroken: false,
+    newPassed: false,
+    retry: false,
+    hidden: false,
+    retriesCount: 0,
+    retriesStatusChange: false,
+    beforeStages: [] as StubStep[],
+    afterStages: [] as StubStep[],
+    labels: [{ name: 'suite', value: 'MySuite' }],
+    links: [{ name: 'GitHub', url: 'https://github.com', type: 'custom' }],
+    parameters: [{ name: 'device', value: 'Pixel' }],
+  };
+}
+
+describe('mapCompiledTestCase', () => {
+  let source: ReturnType<typeof baseCompiledTestCase>;
+  beforeEach(() => { source = baseCompiledTestCase(); });
+  const result = () => mapCompiledTestCase(source);
+
+  describe('.uuid', () => {
+    it('should map from uid', () => {
+      source.uid = 'xyz';
+      expect(result().uuid).to.equal('xyz');
+    });
+  });
+
+  describe('.historyId', () => {
+    it('should pass through', () => {
+      source.historyId = 'h1';
+      expect(result().historyId).to.equal('h1');
+    });
+  });
+
+  describe('.name', () => {
+    it('should pass through', () => {
+      source.name = 'My Test';
+      expect(result().name).to.equal('My Test');
+    });
+  });
+
+  describe('.fullName', () => {
+    it('should pass through', () => {
+      source.fullName = '[ios] Suite - My Test';
+      expect(result().fullName).to.equal('[ios] Suite - My Test');
+    });
+  });
+
+  describe('.start / .stop', () => {
+    it('should flatten from time.start', () => {
+      source.time = { start: 100, stop: 200, duration: 100 };
+      expect(result().start).to.equal(100);
+    });
+
+    it('should flatten from time.stop', () => {
+      source.time = { start: 100, stop: 200, duration: 100 };
+      expect(result().stop).to.equal(200);
+    });
+  });
+
+  describe('.stage', () => {
+    it('should always be "finished"', () => {
+      expect(result().stage).to.equal('finished');
+    });
+  });
+
+  describe('.status', () => {
+    for (const s of ['passed', 'failed', 'broken', 'skipped'] as const) {
+      it(`should pass through "${s}"`, () => {
+        source.status = s;
+        expect(result().status).to.equal(s);
+      });
+    }
+  });
+
+  describe('.descriptionHtml', () => {
+    it('should pass through when present', () => {
+      (source as any).descriptionHtml = '<p>Hello</p>';
+      expect(result().descriptionHtml).to.equal('<p>Hello</p>');
+    });
+
+    it('should be omitted when absent', () => {
+      expect(result()).to.not.have.property('descriptionHtml');
+    });
+  });
+
+  describe('.statusDetails', () => {
+    it('should map from statusMessage and statusTrace', () => {
+      (source as any).statusMessage = 'Assertion failed';
+      (source as any).statusTrace = 'at line 42';
+      expect(result().statusDetails).to.deep.equal({ message: 'Assertion failed', trace: 'at line 42' });
+    });
+
+    it('should map message only when no trace', () => {
+      (source as any).statusMessage = 'Timeout';
+      expect(result().statusDetails).to.deep.equal({ message: 'Timeout' });
+    });
+
+    it('should map trace only when no message', () => {
+      (source as any).statusTrace = 'stack trace';
+      expect(result().statusDetails).to.deep.equal({ trace: 'stack trace' });
+    });
+
+    it('should be omitted when both are absent', () => {
+      expect(result()).to.not.have.property('statusDetails');
+    });
+  });
+
+  describe('.labels (passthrough)', () => {
+    it('should pass through original labels', () => {
+      source.labels = [{ name: 'owner', value: 'team-a' }];
+      expect(result().labels).to.deep.include({ name: 'owner', value: 'team-a' });
+    });
+
+    it('should default to empty when absent', () => {
+      (source as any).labels = undefined;
+      expect(result().labels).to.deep.equal([]);
+    });
+  });
+
+  describe('.labels (synthetic)', () => {
+    it('should add allure2.flaky when true', () => {
+      source.flaky = true;
+      expect(result().labels).to.deep.include({ name: 'allure2.flaky', value: 'true' });
+    });
+
+    it('should add allure2.retry when true', () => {
+      source.retry = true;
+      expect(result().labels).to.deep.include({ name: 'allure2.retry', value: 'true' });
+    });
+
+    it('should add allure2.hidden when true', () => {
+      source.hidden = true;
+      expect(result().labels).to.deep.include({ name: 'allure2.hidden', value: 'true' });
+    });
+
+    it('should add allure2.retriesStatusChange when true', () => {
+      source.retriesStatusChange = true;
+      expect(result().labels).to.deep.include({ name: 'allure2.retriesStatusChange', value: 'true' });
+    });
+
+    it('should add allure2.newFailed when true', () => {
+      source.newFailed = true;
+      expect(result().labels).to.deep.include({ name: 'allure2.newFailed', value: 'true' });
+    });
+
+    it('should add allure2.newBroken when true', () => {
+      source.newBroken = true;
+      expect(result().labels).to.deep.include({ name: 'allure2.newBroken', value: 'true' });
+    });
+
+    it('should add allure2.newPassed when true', () => {
+      source.newPassed = true;
+      expect(result().labels).to.deep.include({ name: 'allure2.newPassed', value: 'true' });
+    });
+
+    it('should add allure2.retriesCount when > 0', () => {
+      source.retriesCount = 3;
+      expect(result().labels).to.deep.include({ name: 'allure2.retriesCount', value: '3' });
+    });
+
+    it('should not add any synthetic labels when all falsy/zero', () => {
+      const syntheticNames = result().labels!.filter((l) => l.name.startsWith('allure2.'));
+      expect(syntheticNames).to.have.length(0);
+    });
+  });
+
+  describe('.links', () => {
+    it('should pass through unchanged', () => {
+      source.links = [{ name: 'JIRA', url: 'https://jira.example.com/123', type: 'issue' }];
+      expect(result().links).to.deep.equal([{ name: 'JIRA', url: 'https://jira.example.com/123', type: 'issue' }]);
+    });
+  });
+
+  describe('.parameters', () => {
+    it('should pass through {name, value}', () => {
+      source.parameters = [{ name: 'browser', value: 'chrome' }];
+      expect(result().parameters).to.deep.equal([{ name: 'browser', value: 'chrome' }]);
+    });
+  });
+
+  describe('.steps', () => {
+    it('should concatenate beforeStages + testStage.steps + afterStages', () => {
+      source.beforeStages = [step('setup')];
+      (source as any).testStage = { status: 'passed', steps: [step('test-step', { time: { start: 3, stop: 4, duration: 1 } })] };
+      source.afterStages = [step('teardown', { time: { start: 5, stop: 6, duration: 1 } })];
+      const names = result().steps!.map((s) => s.name);
+      expect(names).to.deep.equal(['setup', 'test-step', 'teardown']);
+    });
+
+    it('should return [] when no testStage (skipped)', () => {
+      source.status = 'skipped';
+      expect(result().steps).to.deep.equal([]);
+    });
+
+    it('should return [] when no testStage (retried broken)', () => {
+      source.status = 'broken';
+      source.retry = true;
+      source.hidden = true;
+      expect(result().steps).to.deep.equal([]);
+    });
+
+    it('should return [] when no testStage ((test execution) meta-entry)', () => {
+      source.name = '(test execution)';
+      expect(result().steps).to.deep.equal([]);
+    });
+
+    it('should include only before/after stages when testStage has empty steps', () => {
+      source.beforeStages = [step('before')];
+      (source as any).testStage = { status: 'passed', steps: [] };
+      source.afterStages = [step('after', { time: { start: 3, stop: 4, duration: 1 } })];
+      const names = result().steps!.map((s) => s.name);
+      expect(names).to.deep.equal(['before', 'after']);
+    });
+
+    it('should preserve nested steps recursively', () => {
+      (source as any).testStage = {
+        status: 'passed',
+        steps: [step('outer', {
+          time: { start: 1, stop: 10, duration: 9 },
+          steps: [step('inner', { time: { start: 2, stop: 5, duration: 3 } })],
+        })],
+      };
+      expect(result().steps![0].steps![0].name).to.equal('inner');
+    });
+
+    it('should flatten step time.start / time.stop', () => {
+      (source as any).testStage = {
+        status: 'passed',
+        steps: [step('s', { time: { start: 10, stop: 20, duration: 10 } })],
+      };
+      expect(result().steps![0].start).to.equal(10);
+      expect(result().steps![0].stop).to.equal(20);
+    });
+
+    it('should set step stage to "finished"', () => {
+      (source as any).testStage = {
+        status: 'passed',
+        steps: [step('s')],
+      };
+      expect(result().steps![0].stage).to.equal('finished');
+    });
+  });
+
+  describe('.steps[].attachments', () => {
+    it('should map name/type/source/size and drop uid', () => {
+      (source as any).testStage = {
+        status: 'passed',
+        steps: [step('s', {
+          attachments: [{ uid: 'drop-me', name: 'screenshot.png', type: 'image/png', source: '/path/to/file.png', size: 1024 }],
+        })],
+      };
+      const att = result().steps![0].attachments![0];
+      expect(att).to.deep.equal({ name: 'screenshot.png', type: 'image/png', source: '/path/to/file.png', size: 1024 });
+      expect(att).to.not.have.property('uid');
+    });
+
+    it('should omit size when absent', () => {
+      (source as any).testStage = {
+        status: 'passed',
+        steps: [step('s', {
+          attachments: [{ uid: 'x', name: 'log.txt', type: 'text/plain', source: '/path/log.txt' }],
+        })],
+      };
+      expect(result().steps![0].attachments![0]).to.not.have.property('size');
+    });
+  });
+
+  describe('.steps[].parameters', () => {
+    it('should pass through step parameters', () => {
+      (source as any).testStage = {
+        status: 'passed',
+        steps: [step('s', { parameters: [{ name: 'id', value: 'my-button' }] })],
+      };
+      expect(result().steps![0].parameters).to.deep.equal([{ name: 'id', value: 'my-button' }]);
+    });
+  });
+});
+
+describe('CompiledAllureReader', () => {
+  function mockSource(files: Record<string, string>): CompiledReportSource {
+    return {
+      readFile: async (p: string) => files[p] ?? null,
+      listFiles: async (prefix: string) => Object.keys(files).filter((k) => k.startsWith(prefix)),
+    };
+  }
+
+  function readerFor(files: Record<string, string>): CompiledAllureReader {
+    return new CompiledAllureReader({ source: mockSource(files), onError: 'ignore' });
+  }
+
+  describe('getResultIds', () => {
+    it('should list all test case UIDs', async () => {
+      const reader = readerFor({
+        'data/test-cases/aaa.json': '{}',
+        'data/test-cases/bbb.json': '{}',
+      });
+      const ids = await reader.getResultIds();
+      expect(ids).to.have.members(['aaa', 'bbb']);
+    });
+  });
+
+  describe('getContainerIds', () => {
+    it('should always return empty', async () => {
+      expect(await readerFor({}).getContainerIds()).to.deep.equal([]);
+    });
+  });
+
+  describe('readContainer', () => {
+    it('should always return null', async () => {
+      expect(await readerFor({}).readContainer('any')).to.equal(null);
+    });
+  });
+
+  describe('readCategories', () => {
+    it('should always return null', async () => {
+      expect(await readerFor({}).readCategories()).to.equal(null);
+    });
+  });
+
+  describe('readResult', () => {
+    it('should return null for missing file', async () => {
+      expect(await readerFor({}).readResult('missing')).to.equal(null);
+    });
+
+    it('should return null for invalid JSON', async () => {
+      const reader = readerFor({ 'data/test-cases/bad.json': 'not json' });
+      expect(await reader.readResult('bad')).to.equal(null);
+    });
+
+    it('should map a valid test case', async () => {
+      const tc = JSON.stringify(baseCompiledTestCase());
+      const reader = readerFor({ 'data/test-cases/abc123.json': tc });
+      const r = await reader.readResult('abc123');
+      expect(r).to.not.equal(null);
+      expect(r!.uuid).to.equal('abc123');
+      expect(r!.stage).to.equal('finished');
+    });
+  });
+
+  describe('readEnvironmentInfo', () => {
+    it('should convert [{name, values}] to Record<string, string>', async () => {
+      const env = JSON.stringify([
+        { name: 'version.node', values: ['v20.20.1'] },
+        { name: 'multi', values: ['a', 'b'] },
+      ]);
+      const reader = readerFor({ 'widgets/environment.json': env });
+      const info = await reader.readEnvironmentInfo();
+      expect(info).to.deep.equal({ 'version.node': 'v20.20.1', 'multi': 'a,b' });
+    });
+
+    it('should return null when file is missing', async () => {
+      expect(await readerFor({}).readEnvironmentInfo()).to.equal(null);
+    });
+  });
+
+  describe('readExecutorInfo', () => {
+    it('should return first executor from array', async () => {
+      const executors = JSON.stringify([{ name: 'machine-1', type: 'buildkite', buildOrder: 100 }]);
+      const reader = readerFor({ 'widgets/executors.json': executors });
+      const info = await reader.readExecutorInfo();
+      expect(info).to.deep.equal({ name: 'machine-1', type: 'buildkite', buildOrder: 100 });
+    });
+
+    it('should return null for empty array', async () => {
+      expect(await readerFor({ 'widgets/executors.json': '[]' }).readExecutorInfo()).to.equal(null);
+    });
+
+    it('should return null when file is missing', async () => {
+      expect(await readerFor({}).readExecutorInfo()).to.equal(null);
+    });
+  });
+});

--- a/src/CompiledAllureReader.ts
+++ b/src/CompiledAllureReader.ts
@@ -1,0 +1,229 @@
+import type { AllureReader } from './AllureReader';
+import type { CompiledReportSource } from './CompiledReportSource';
+import type { Attachment, Category, Container, ExecutorInfo, Label, Result, Status, Step } from './types';
+import { AllureStoreError, type OnErrorHandler, resolveOnError } from './errors';
+
+export interface CompiledAllureReaderConfig {
+  source: CompiledReportSource;
+  onError?: OnErrorHandler;
+}
+
+export class CompiledAllureReader implements AllureReader {
+  readonly #source: CompiledReportSource;
+  readonly #onError: (error: Error) => void;
+
+  constructor(config: CompiledAllureReaderConfig) {
+    this.#source = config.source;
+    this.#onError = resolveOnError(config.onError ?? 'throw');
+  }
+
+  async init(): Promise<void> {
+    await this.#source.init?.();
+  }
+
+  async getContainerIds(): Promise<string[]> {
+    return [];
+  }
+
+  async getResultIds(): Promise<string[]> {
+    const files = await this.#source.listFiles('data/test-cases');
+    return files.map((f) => {
+      const basename = f.split('/').pop()!;
+      return basename.replace(/\.json$/, '');
+    });
+  }
+
+  async readResult(id: string): Promise<Result | null> {
+    const content = await this.#source.readFile(`data/test-cases/${id}.json`);
+    if (!content) return null;
+    try {
+      return mapCompiledTestCase(JSON.parse(content));
+    } catch (error: unknown) {
+      this.#handleError(`Failed to parse compiled test case: ${id}`, error);
+      return null;
+    }
+  }
+
+  async readContainer(_id: string): Promise<Container | null> {
+    return null;
+  }
+
+  async readCategories(): Promise<Category[] | null> {
+    return null;
+  }
+
+  async readEnvironmentInfo(): Promise<Record<string, string> | null> {
+    const content = await this.#source.readFile('widgets/environment.json');
+    if (!content) return null;
+    try {
+      const entries: { name: string; values: string[] }[] = JSON.parse(content);
+      const result: Record<string, string> = {};
+      for (const entry of entries) {
+        result[entry.name] = entry.values.join(',');
+      }
+      return result;
+    } catch (error: unknown) {
+      this.#handleError('Failed to parse environment info', error);
+      return null;
+    }
+  }
+
+  async readExecutorInfo(): Promise<ExecutorInfo | null> {
+    const content = await this.#source.readFile('widgets/executors.json');
+    if (!content) return null;
+    try {
+      const executors: ExecutorInfo[] = JSON.parse(content);
+      return executors[0] ?? null;
+    } catch (error: unknown) {
+      this.#handleError('Failed to parse executor info', error);
+      return null;
+    }
+  }
+
+  #handleError(message: string, cause?: unknown): void {
+    this.#onError(new AllureStoreError(message, cause));
+  }
+}
+
+interface CompiledTime {
+  start: number;
+  stop: number;
+  duration: number;
+}
+
+interface CompiledAttachment {
+  uid?: string;
+  name: string;
+  type: string;
+  source: string;
+  size?: number;
+}
+
+interface CompiledStep {
+  name: string;
+  time?: CompiledTime;
+  status: Status;
+  statusMessage?: string;
+  statusTrace?: string;
+  steps?: CompiledStep[];
+  attachments?: CompiledAttachment[];
+  parameters?: { name: string; value: string }[];
+}
+
+interface CompiledTestStage {
+  status: Status;
+  steps?: CompiledStep[];
+  attachments?: CompiledAttachment[];
+  parameters?: { name: string; value: string }[];
+}
+
+type CompiledBooleanFlag = 'flaky' | 'retry' | 'hidden' | 'retriesStatusChange' | 'newFailed' | 'newBroken' | 'newPassed';
+
+interface CompiledTestCase {
+  uid: string;
+  historyId: string;
+  name: string;
+  fullName: string;
+  time: CompiledTime;
+  descriptionHtml?: string;
+  status: Status;
+  statusMessage?: string;
+  statusTrace?: string;
+  flaky?: boolean;
+  newFailed?: boolean;
+  newBroken?: boolean;
+  newPassed?: boolean;
+  retry?: boolean;
+  hidden?: boolean;
+  retriesCount?: number;
+  retriesStatusChange?: boolean;
+  beforeStages?: CompiledStep[];
+  testStage?: CompiledTestStage;
+  afterStages?: CompiledStep[];
+  labels?: Label[];
+  links?: { name?: string; url: string; type?: string }[];
+  parameters?: { name: string; value: string }[];
+}
+
+export function mapCompiledTestCase(source: CompiledTestCase): Result {
+  const labels = [...(source.labels ?? [])];
+  addSyntheticLabels(labels, source);
+
+  return {
+    uuid: source.uid,
+    historyId: source.historyId,
+    name: source.name,
+    fullName: source.fullName,
+    start: source.time.start,
+    stop: source.time.stop,
+    ...(source.descriptionHtml ? { descriptionHtml: source.descriptionHtml } : {}),
+    stage: 'finished',
+    status: source.status,
+    ...mapStatusDetails(source),
+    labels,
+    ...(source.links ? { links: source.links } : {}),
+    ...(source.parameters ? { parameters: source.parameters } : {}),
+    steps: assembleSteps(source),
+  };
+}
+
+function mapStatusDetails(source: { statusMessage?: string; statusTrace?: string }) {
+  if (!source.statusMessage && !source.statusTrace) return {};
+  return {
+    statusDetails: {
+      ...(source.statusMessage ? { message: source.statusMessage } : {}),
+      ...(source.statusTrace ? { trace: source.statusTrace } : {}),
+    },
+  };
+}
+
+const SYNTHETIC_BOOLEAN_LABELS: [CompiledBooleanFlag, string][] = [
+  ['flaky', 'allure2.flaky'],
+  ['retry', 'allure2.retry'],
+  ['hidden', 'allure2.hidden'],
+  ['retriesStatusChange', 'allure2.retriesStatusChange'],
+  ['newFailed', 'allure2.newFailed'],
+  ['newBroken', 'allure2.newBroken'],
+  ['newPassed', 'allure2.newPassed'],
+];
+
+function addSyntheticLabels(labels: Label[], source: CompiledTestCase): void {
+  for (const [key, labelName] of SYNTHETIC_BOOLEAN_LABELS) {
+    if (source[key]) {
+      labels.push({ name: labelName, value: 'true' });
+    }
+  }
+  if (source.retriesCount && source.retriesCount > 0) {
+    labels.push({ name: 'allure2.retriesCount', value: String(source.retriesCount) });
+  }
+}
+
+function assembleSteps(source: CompiledTestCase): Step[] {
+  const before = (source.beforeStages ?? []).map(mapStep);
+  const test = source.testStage?.steps?.map(mapStep) ?? [];
+  const after = (source.afterStages ?? []).map(mapStep);
+  return [...before, ...test, ...after];
+}
+
+function mapStep(step: CompiledStep): Step {
+  return {
+    name: step.name,
+    start: step.time?.start ?? 0,
+    stop: step.time?.stop ?? 0,
+    stage: 'finished',
+    status: step.status,
+    ...mapStatusDetails(step),
+    ...(step.steps?.length ? { steps: step.steps.map(mapStep) } : {}),
+    ...(step.attachments?.length ? { attachments: step.attachments.map(mapAttachment) } : {}),
+    ...(step.parameters?.length ? { parameters: step.parameters } : {}),
+  };
+}
+
+function mapAttachment(att: CompiledAttachment): Attachment {
+  return {
+    name: att.name,
+    type: att.type,
+    source: att.source,
+    ...(att.size == null ? {} : { size: att.size }),
+  };
+}

--- a/src/CompiledReportSource.ts
+++ b/src/CompiledReportSource.ts
@@ -1,0 +1,134 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export interface CompiledReportSource {
+  init?(): Promise<void>;
+  readFile(relativePath: string): Promise<string | null>;
+  listFiles(prefix: string): Promise<string[]>;
+}
+
+export function stripFileProtocol(input: string): string {
+  return input.startsWith('file://') ? input.slice(7) : input;
+}
+
+export class FileReportSource implements CompiledReportSource {
+  readonly #dir: string;
+
+  constructor(dir: string) {
+    this.#dir = dir;
+  }
+
+  async readFile(relativePath: string): Promise<string | null> {
+    const resolved = path.resolve(this.#dir, relativePath);
+    if (!resolved.startsWith(path.resolve(this.#dir) + path.sep)) return null;
+    try {
+      return await fs.readFile(resolved, 'utf8');
+    } catch {
+      return null;
+    }
+  }
+
+  async listFiles(prefix: string): Promise<string[]> {
+    const dir = path.resolve(this.#dir, prefix);
+    if (!dir.startsWith(path.resolve(this.#dir) + path.sep)) return [];
+    try {
+      const entries = await fs.readdir(dir);
+      return entries.map((e) => `${prefix}/${e}`);
+    } catch {
+      return [];
+    }
+  }
+}
+
+export class UrlReportSource implements CompiledReportSource {
+  readonly #baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.#baseUrl = baseUrl.replace(/\/+$/, '');
+  }
+
+  async readFile(relativePath: string): Promise<string | null> {
+    try {
+      const response = await fetch(`${this.#baseUrl}/${relativePath}`);
+      if (!response.ok) return null;
+      return await response.text();
+    } catch {
+      return null;
+    }
+  }
+
+  // Only 'data/test-cases' is supported — URL-based reports have no directory listing,
+  // so test case UIDs are discovered via 'widgets/status-chart.json' instead.
+  async listFiles(prefix: string): Promise<string[]> {
+    if (prefix === 'data/test-cases') {
+      return this.#listTestCaseFiles();
+    }
+    return [];
+  }
+
+  async #listTestCaseFiles(): Promise<string[]> {
+    const content = await this.readFile('widgets/status-chart.json');
+    if (!content) return [];
+    try {
+      const entries: { uid: string }[] = JSON.parse(content);
+      return entries.map((e) => `data/test-cases/${e.uid}.json`);
+    } catch {
+      return [];
+    }
+  }
+}
+
+const HTML_DATA_PATTERN = /\bd\(["']([^"']+)["'],\s*["']([^"']+)["']\)/;
+const HTML_DATA_PATTERN_GLOBAL = new RegExp(HTML_DATA_PATTERN, 'g');
+
+export class HtmlReportSource implements CompiledReportSource {
+  readonly #input: string;
+  readonly #prefetched: string | undefined;
+  readonly #files = new Map<string, string>();
+
+  constructor(fileOrUrl: string, prefetchedHtml?: string) {
+    this.#input = fileOrUrl;
+    this.#prefetched = prefetchedHtml;
+  }
+
+  async init(): Promise<void> {
+    const html = this.#prefetched ?? await this.#fetchHtml();
+    if (!html) return;
+
+    for (const match of html.matchAll(HTML_DATA_PATTERN_GLOBAL)) {
+      this.#files.set(match[1], Buffer.from(match[2], 'base64').toString('utf8'));
+    }
+  }
+
+  async readFile(relativePath: string): Promise<string | null> {
+    return this.#files.get(relativePath) ?? null;
+  }
+
+  async listFiles(prefix: string): Promise<string[]> {
+    return [...this.#files.keys()].filter((k) => k.startsWith(prefix));
+  }
+
+  async #fetchHtml(): Promise<string | null> {
+    const input = this.#input;
+
+    if (input.startsWith('http://') || input.startsWith('https://')) {
+      try {
+        const response = await fetch(input);
+        if (!response.ok) return null;
+        return await response.text();
+      } catch {
+        return null;
+      }
+    }
+
+    try {
+      return await fs.readFile(stripFileProtocol(input), 'utf8');
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function containsHtmlDataCalls(content: string): boolean {
+  return HTML_DATA_PATTERN.test(content);
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,7 +14,9 @@ export function resolveOnError(onError: OnErrorHandler): (error: Error) => void 
 }
 
 export class AllureStoreError extends Error {
-  constructor(message: string, public readonly cause?: unknown) {
+  override readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
     super(message, { cause });
     this.name = 'AllureStoreError';
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type {AllureStoreConfig, AllureStoreDirectoryConfig} from './AllureStore';
+import type { AllureStoreConfig, AllureStoreDirectoryConfig, AllureStoreReportConfig } from './AllureStore';
 import { AllureStore } from './AllureStore';
 
 /**
@@ -9,15 +9,37 @@ export async function fromConfig(options: AllureStoreConfig): Promise<AllureStor
 }
 
 /**
- * Create an AllureStore from a directory configuration.
+ * Create an AllureStore from a directory of raw allure-results.
  */
 export async function fromDirectory(resultsDirectory: string, options?: AllureStoreDirectoryConfig): Promise<AllureStore> {
   return AllureStore.fromDirectory(resultsDirectory, options);
 }
 
+/**
+ * Create an AllureStore from a compiled Allure2 report with auto-detection.
+ *
+ * Accepts a local directory, a local HTML file, or an HTTP(S) URL.
+ * Detects the input type heuristically:
+ * - `file://` URLs are resolved to local paths
+ * - Local directories use {@link FileReportSource}
+ * - Local files are treated as single-file HTML reports via {@link HtmlReportSource}
+ * - HTTP(S) URLs returning HTML with embedded data use {@link HtmlReportSource}
+ * - HTTP(S) URLs returning the Allure UI shell use {@link UrlReportSource}
+ */
+export async function fromReport(input: string, options?: AllureStoreReportConfig): Promise<AllureStore> {
+  return AllureStore.fromReport(input, options);
+}
+
 export { type AllureReader } from './AllureReader';
 export { type AllureWriter } from './AllureWriter';
-export { AllureStore, type AllureStoreConfig, type AllureStoreDirectoryConfig } from './AllureStore';
+export { AllureStore, type AllureStoreConfig, type AllureStoreDirectoryConfig, type AllureStoreReportConfig } from './AllureStore';
 export { FileAllureWriter, type FileSystemAllureWriterConfig } from './FileAllureWriter';
 export { FileAllureReader, type FileAllureReaderConfig } from './FileAllureReader';
+export { CompiledAllureReader, type CompiledAllureReaderConfig } from './CompiledAllureReader';
+export {
+  type CompiledReportSource,
+  FileReportSource,
+  UrlReportSource,
+  HtmlReportSource,
+} from './CompiledReportSource';
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface Attachment {
   name: string;
   type: string;
   source: string;
+  size?: number;
 }
 
 /**


### PR DESCRIPTION
Add read-only support for compiled Allure2 reports (the output of `allure generate`). This enables reading test results from:

- Local report directories
- Single-file HTML reports (with embedded base64 data)
- HTTP(S) URLs (auto-detects multi-file vs single-file)

The entry point is `fromReport(input)`, which heuristically detects the input type and selects the appropriate source backend.